### PR TITLE
Fix some problems when server is in cache mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.egg-info
 dist
 build
+.eggs
 eggs
 parts
 bin

--- a/pypicloud/util.py
+++ b/pypicloud/util.py
@@ -36,6 +36,10 @@ class BetterScrapingLocator(SimpleScrapingLocator):
     """ Layer on top of SimpleScrapingLocator that allows preferring wheels """
     prefer_wheel = True
 
+    def __init__(self, *args, **kw):
+        kw['scheme'] = 'legacy'
+        super(BetterScrapingLocator, self).__init__(*args, **kw)
+
     def locate(self, requirement, prereleases=False, wheel=True):
         self.prefer_wheel = wheel
         super(BetterScrapingLocator, self).locate(requirement, prereleases)


### PR DESCRIPTION
* Packages on PYPI with older versions which have invalid PEP440 versions
   would crash distlib in default mode