### PR TITLE
Correct time comparison in s3.py, get_url

### DIFF
--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -139,15 +139,15 @@ class S3Storage(IStorage):
             # See issue: https://github.com/mathcamp/pypicloud/issues/38
             credential_expr = getattr(self.bucket.connection.provider,
                                       '_credential_expiry_time', None)
+            expire_time = time.time() + expire_after
             if credential_expr is not None:
                 seconds = calendar.timegm(credential_expr.utctimetuple())
-                if seconds < expire_after:
+                if seconds < expire_time:
                     # More hacks: boto refreshes session tokens 5 minutes
                     # before expiration, so we have to refresh url after that.
                     buffer_time = 4 * 60
-                    expire_after = seconds
+                    expire_time = seconds
 
-            expire_time = time.time() + expire_after
             url = key.generate_url(expire_time, expires_in_absolute=True)
             package.data['url'] = url
             expire = expire_time - buffer_time


### PR DESCRIPTION
As it is now, in the case of temporary credentials, there is an inconsistent comparison between `seconds` which has a unix timestamp value and `expire_after` which is an arbitrary number of seconds. As a result `if seconds < expire_after:` always returns `False` and the expiration time does not get updated correctly. This commit fixes that (cc @stevearc).