### PR TITLE
Fixed fallback mirror mode

### DIFF
--- a/pypicloud/views/simple.py
+++ b/pypicloud/views/simple.py
@@ -65,7 +65,7 @@ def package_versions(context, request):
     pkgs = {}
     if fallback == 'mirror':
         if can_update_cache:
-            pkgs = get_fallback_packages(request, context.name)
+            pkgs = get_fallback_packages(request, context.name) or {}
         if packages:
             # Overwrite upstream urls with cached urls
             for package in packages:


### PR DESCRIPTION
Bug fixed when private package needs to be download and not found in fallback url, the get_fallback_packages returns None and then there is an assignment for NoneType. fixed with returning empty dict in case None has returned (usually for private packages not stored in fallback url's which are mostly wide)