### PR TITLE
hooks exception formatting to allow multiline tracebacks in a single json log

### DIFF
--- a/pypicloud/__init__.py
+++ b/pypicloud/__init__.py
@@ -100,7 +100,6 @@ def includeme(config):
                            cache_max_age=cache_max_age)
 
 
-
 def traceback_formatter(excpt, value, tback):
     """ Catches all exceptions and re-formats the traceback raised.
     """
@@ -113,7 +112,7 @@ def hook_exceptions():
     """
 
     # reopen stdout in non buffered mode
-    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+    sys.stdout = os.fdopen(getattr(sys.stdout, "fileno", lambda: 1)(), 'w', 0)
     # set the hook
     sys.excepthook = traceback_formatter
 

--- a/pypicloud/__init__.py
+++ b/pypicloud/__init__.py
@@ -1,4 +1,7 @@
 """ S3-backed pypi server """
+import os
+import sys
+import traceback
 import datetime
 
 import logging
@@ -97,9 +100,28 @@ def includeme(config):
                            cache_max_age=cache_max_age)
 
 
+
+def traceback_formatter(excpt, value, tback):
+    """ Catches all exceptions and re-formats the traceback raised.
+    """
+
+    sys.stdout.write("".join(traceback.format_exception(excpt, value, tback)))
+
+
+def hook_exceptions():
+    """ Hooks into the sys module to set our formatter.
+    """
+
+    # reopen stdout in non buffered mode
+    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+    # set the hook
+    sys.excepthook = traceback_formatter
+
+
 def main(config, **settings):
     """ This function returns a Pyramid WSGI application.
     """
+    hook_exceptions()
     config = Configurator(settings=settings)
     config.include('pypicloud')
     config.scan('pypicloud.views')

--- a/pypicloud/__init__.py
+++ b/pypicloud/__init__.py
@@ -111,10 +111,11 @@ def hook_exceptions():
     """ Hooks into the sys module to set our formatter.
     """
 
-    # reopen stdout in non buffered mode
-    sys.stdout = os.fdopen(getattr(sys.stdout, "fileno", lambda: 1)(), 'w', 0)
-    # set the hook
-    sys.excepthook = traceback_formatter
+    if hasattr(sys.stdout, "fileno"):  # when testing, sys.stdout is StringIO
+        # reopen stdout in non buffered mode
+        sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+        # set the hook
+        sys.excepthook = traceback_formatter
 
 
 def main(config, **settings):


### PR DESCRIPTION
currently tracebacks are split across multiple lines/log messages, this will keep them together