### PR TITLE
Add view for all packages

### DIFF
--- a/pypicloud/views/packages.py
+++ b/pypicloud/views/packages.py
@@ -3,7 +3,7 @@ from pyramid.view import view_config
 from pyramid_duh import addslash
 
 from pypicloud.route import PackagesResource
-from pypicloud.views.simple import _packages_to_dict
+from pypicloud.views.simple import packages_to_dict
 
 
 @view_config(context=PackagesResource, request_method='GET', subpath=(),
@@ -18,4 +18,4 @@ def list_packages(request):
     packages = []
     for package_name in names:
         packages += request.db.all(package_name)
-    return {'pkgs': _packages_to_dict(request, packages)}
+    return {'pkgs': packages_to_dict(request, packages)}

--- a/pypicloud/views/simple.py
+++ b/pypicloud/views/simple.py
@@ -84,7 +84,7 @@ def get_fallback_packages(request, package_name, redirect=True):
     return pkgs
 
 
-def _packages_to_dict(request, packages):
+def packages_to_dict(request, packages):
     """ Convert a list of packages to a dict used by the template """
     pkgs = {}
     for package in packages:
@@ -118,7 +118,7 @@ def _simple_redirect(context, request):
             else:
                 return request.request_login()
         else:
-            return _pkg_response(_packages_to_dict(request, packages))
+            return _pkg_response(packages_to_dict(request, packages))
     else:
         return _redirect(context, request)
 
@@ -135,7 +135,7 @@ def _simple_cache(context, request):
 
     packages = request.db.all(normalized_name)
     if packages:
-        return _pkg_response(_packages_to_dict(request, packages))
+        return _pkg_response(packages_to_dict(request, packages))
 
     if not request.access.can_update_cache():
         if request.is_logged_in:
@@ -162,7 +162,7 @@ def _simple_mirror(context, request):
         if not request.access.can_update_cache():
             if request.is_logged_in:
                 pkgs = get_fallback_packages(request, context.name)
-                stored_pkgs = _packages_to_dict(request, packages)
+                stored_pkgs = packages_to_dict(request, packages)
                 # Overwrite existing package urls
                 for filename, url in six.iteritems(stored_pkgs):
                     pkgs[filename] = url
@@ -171,7 +171,7 @@ def _simple_mirror(context, request):
                 return request.request_login()
         else:
             pkgs = get_fallback_packages(request, context.name, False)
-            stored_pkgs = _packages_to_dict(request, packages)
+            stored_pkgs = packages_to_dict(request, packages)
             # Overwrite existing package urls
             for filename, url in six.iteritems(stored_pkgs):
                 pkgs[filename] = url
@@ -198,4 +198,4 @@ def _simple_serve(context, request):
             return request.request_login()
 
     packages = request.db.all(normalized_name)
-    return _pkg_response(_packages_to_dict(request, packages))
+    return _pkg_response(packages_to_dict(request, packages))

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -23,7 +23,7 @@ class TestPackages(MockServerTest):
         def get_packages(x):
             """ Returns a list of mocked package objects for this package """
             def mm(package_name):
-                """ Mock packages for _packages_to_dict """
+                """ Mock packages for packages_to_dict """
                 p = MagicMock()
                 p.filename = package_name
                 p.get_url.return_value = package_name + ".ext"


### PR DESCRIPTION
currently we need to define link for every package in pypicloud separately in buildout.cfg, example:
find-links +=
    https://whatever.herokuapp.com/simple/package1
    https://whatever.herokuapp.com/simple/package2

with this change you can have cleaner buildout config files which is very nice when you have many packages, example:
find-links +=
    https://whatever.herokuapp.com/packages