### PR TITLE
handle unparseable package name

### DIFF
--- a/pypicloud/util.py
+++ b/pypicloud/util.py
@@ -17,7 +17,11 @@ def parse_filename(filename, name=None):
     for ext in ALL_EXTENSIONS:
         if filename.endswith(ext):
             trimmed = filename[:-len(ext)]
-            parsed_name, version = split_filename(trimmed, name)[:2]
+            parsed = split_filename(trimmed, name)
+            if parsed is None:
+                break
+            else:
+                parsed_name, version = parsed[:2]
             break
     if version is None:
         raise ValueError("Cannot parse package file '%s'" % filename)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -16,6 +16,11 @@ class TestParse(unittest.TestCase):
         self.assertEqual(name, 'mypkg')
         self.assertEqual(version, '1.1')
 
+    def test_invalid_source(self):
+        """ Parse fails on invalid package name """
+        with self.assertRaises(ValueError):
+            util.parse_filename('invalid_package_name.tar.gz')
+
     def test_valid_wheel(self):
         """ Parse a valid wheel package """
         name, version = util.parse_filename('mypkg-1.1-py2.py3-none-any.whl')


### PR DESCRIPTION
Our company has fairly complicated package names. This is not a problem if we are able to pass the `name` argument to `parse_filename`, but in the case where `name` is `None` (for example when rebuilding from the cache) the application crashes with the following exception:

    File "/env/local/lib/python2.7/site-packages/pypicloud/util.py", line 22, in parse_filename
    parsed_name, version = split_filename(trimmed, name)[:2]
    TypeError: 'NoneType' object has no attribute '__getitem__'

This pull request extends `parse_filename` to raise a `ValueError` not only for invalid extensions, but for invalid package names as well.

The offending package name is of the form:
`Package_name_python2.7_ubuntu_14.04_x64-2016.2b3-py2`