### PR TITLE
Cloudfront support

### DIFF
--- a/doc/topics/storage.rst
+++ b/doc/topics/storage.rst
@@ -75,3 +75,36 @@ How long (in seconds) the generated S3 urls are valid for (default 86400 (1
 day)). In practice, there is no real reason why these generated urls need to
 expire at all. S3 does it for security, but expiring links isn't part of the
 python package security model. So in theory you can bump this number up.
+
+CloudFront
+--
+This option will store your packages in S3 but use CloudFront to deliver the packages.
+This is an extension of the S3 storage backend and require the same settings as above,
+but also the settings listed below.
+
+Set ``pypi.storage = cloudfront`` OR ``pypi.s3 = pypicloud.storage.CloudFrontS3Storage``
+
+``storage.cloud_front_domain``
+~~~~~~~~~~~~~~~~~~
+**Argument:** string
+
+The CloudFront domain you have set up. This CloudFront distribution must be set up to
+use your S3 bucket as the origin.
+
+Example: ``https://dabcdefgh12345.cloudfront.net``
+
+``storage.cloud_front_key_id``
+~~~~~~~~~~~~~~~~~~
+**Argument:** string, optional
+
+If you want to protect your packages from public access you need to set up the CloudFront
+distribution to use signed URLs. This setting specifies the key id of the [CloudFront
+key pair](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html)
+that is currently active on your AWS account.
+
+``storage.cloud_front_key_file``
+~~~~~~~~~~~~~~~~~~
+**Argument:** string, optional
+
+Only needed when setting up CloudFront with signed URLs. This setting should be
+set to the full path of the CloudFront private key file.

--- a/pypicloud/storage/__init__.py
+++ b/pypicloud/storage/__init__.py
@@ -3,7 +3,7 @@ from functools import partial
 
 from .base import IStorage
 from .files import FileStorage
-from .s3 import S3Storage
+from .s3 import S3Storage, CloudFrontS3Storage
 
 from pyramid.path import DottedNameResolver
 

--- a/pypicloud/storage/__init__.py
+++ b/pypicloud/storage/__init__.py
@@ -14,6 +14,8 @@ def get_storage_impl(settings):
     storage = settings.get('pypi.storage', 'file')
     if storage == 's3':
         storage = 'pypicloud.storage.S3Storage'
+    elif storage == 'cloudfront':
+        storage = 'pypicloud.storage.CloudFrontS3Storage'
     elif storage == 'file':
         storage = 'pypicloud.storage.FileStorage'
     storage_impl = resolver.resolve(storage)

--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -85,19 +85,20 @@ class S3Storage(IStorage):
         kwargs['bucket'] = bucket
         return kwargs
 
-    def get_filename(self, package):
-        filename = package.name + '/' + package.filename
+    def calculate_path(self, package):
+        """ Calculates the path of a package """
+        path = package.name + '/' + package.filename
         if self.prepend_hash:
             m = md5()
             m.update(package.filename)
             prefix = m.digest().encode('hex')[:4]
-            filename = prefix + '/' + filename
-        return filename
+            path = prefix + '/' + path
+        return path
 
     def get_path(self, package):
         """ Get the fully-qualified bucket path for a package """
         if 'path' not in package.data:
-            filename = self.get_filename(package)
+            filename = self.calculate_path(package)
             package.data['path'] = self.bucket_prefix + filename
         return package.data['path']
 
@@ -188,8 +189,8 @@ class CloudFrontS3Storage(S3Storage):
 
     def get_url(self, package):
         """ Get the fully-qualified CloudFront path for a package """
-        filename = self.get_filename(package)
-        url = self.cloud_front_domain + '/' + filename
+        path = self.calculate_path(package)
+        url = self.cloud_front_domain + '/' + path
 
         url = url.replace('+', '%2b')
 

--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -159,6 +159,8 @@ class S3Storage(IStorage):
 
 
 class CloudFrontS3Storage(S3Storage):
+
+    """ Storage backend that uses S3 and CloudFront """
     def __init__(self, request=None, bucket=None, expire_after=None, bucket_prefix=None,
                  prepend_hash=None, cloud_front_domain=None, cloud_front_key_file=None,
                  cloud_front_key_string=None, cloud_front_key_id=None, **kwargs):

--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -189,6 +189,8 @@ class CloudFrontS3Storage(S3Storage):
         filename = self.get_filename(package)
         url = self.cloud_front_domain + '/' + filename
 
+        url = url.replace('+', '%2b')
+
         if self.cloud_front_key_file or self.cloud_front_key_string:
             expire_time = int(time.time() + self.expire_after)
             url = self.distribution.create_signed_url(

--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -5,7 +5,7 @@ import posixpath
 import time
 from contextlib import contextmanager
 from hashlib import md5
-from urllib import urlopen
+from urllib import urlopen, quote
 
 import boto.s3
 from boto.cloudfront import Distribution
@@ -190,9 +190,7 @@ class CloudFrontS3Storage(S3Storage):
     def get_url(self, package):
         """ Get the fully-qualified CloudFront path for a package """
         path = self.calculate_path(package)
-        url = self.cloud_front_domain + '/' + path
-
-        url = url.replace('+', '%2b')
+        url = self.cloud_front_domain + '/' + quote(path)
 
         if self.cloud_front_key_file or self.cloud_front_key_string:
             expire_time = int(time.time() + self.expire_after)

--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -176,9 +176,9 @@ class CloudFrontS3Storage(S3Storage):
         kwargs['cloud_front_domain'] = getdefaults(
             settings, 'storage.cloud_front_domain', 'aws.cloud_front_domain', '')
         kwargs['cloud_front_key_file'] = getdefaults(
-            settings, 'storage.cloud_front_key_file', 'aws.cloud_front_key_file', '')
+            settings, 'storage.cloud_front_key_file', 'aws.cloud_front_key_file', None)
         kwargs['cloud_front_key_string'] = getdefaults(
-            settings, 'storage.cloud_front_key_string', 'aws.cloud_front_key_string', '')
+            settings, 'storage.cloud_front_key_string', 'aws.cloud_front_key_string', None)
         kwargs['cloud_front_key_id'] = getdefaults(
             settings, 'storage.cloud_front_key_id', 'aws.cloud_front_key_id', '')
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ REQUIREMENTS = [
     'pyramid_duh>=0.1.1',
     'pyramid_jinja2',
     'pyramid_tm',
+    'rsa',
     'six',
     'transaction',
     'zope.sqlalchemy',

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -182,13 +182,13 @@ class TestCloudFrontS3Storage(TestS3Storage):
 
     def test_get_url(self):
         """ Mock s3 and test package url generation """
-        package = make_package()
+        package = make_package(version="1.1+g12345")
         response = self.storage.download_response(package)
 
         parts = urlparse(response.location)
         self.assertEqual(parts.scheme, 'https')
         self.assertEqual(parts.netloc, 'abcdef.cloudfront.net')
-        self.assertEqual(parts.path, '/' + self.storage.get_path(package))
+        self.assertEqual(parts.path, '/bcc4/mypkg/mypkg-1.1%2Bg12345.tar.gz')
         query = parse_qs(parts.query)
         self.assertItemsEqual(query.keys(), ['Key-Pair-Id', 'Expires',
                                              'Signature'])

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -144,6 +144,9 @@ class TestS3Storage(unittest.TestCase):
 
 
 class TestCloudFrontS3Storage(TestS3Storage):
+
+    """ Tests for storing packages on S3 with CloudFront in front """
+
     def setUp(self):
         super(TestCloudFrontS3Storage, self).setUp()
         self.s3_mock = mock_s3()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -16,7 +16,7 @@ import re
 from boto.s3.key import Key
 import boto.exception
 from pypicloud.models import Package
-from pypicloud.storage import S3Storage, FileStorage
+from pypicloud.storage import S3Storage, CloudFrontS3Storage, FileStorage
 from . import make_package
 
 try:
@@ -141,6 +141,57 @@ class TestS3Storage(unittest.TestCase):
         S3Storage.configure(settings)
         conn.create_bucket.assert_called_with('new_bucket',
                                               location='us-east-1')
+
+
+class TestCloudFrontS3Storage(TestS3Storage):
+    def setUp(self):
+        super(TestCloudFrontS3Storage, self).setUp()
+        self.s3_mock = mock_s3()
+        self.s3_mock.start()
+        self.settings = {
+            'storage.bucket': 'mybucket',
+            'storage.access_key': 'abc',
+            'storage.secret_key': 'bcd',
+            'storage.cloud_front_domain': 'https://abcdef.cloudfront.net',
+            'storage.cloud_front_key_file': '',
+            'storage.cloud_front_key_string': '-----BEGIN RSA PRIVATE KEY-----\n'
+                                              'MIICXQIBAAKBgQDNBN3WHzIgmOEkBVNdBlTR7iGYyUXDVuFRkJlYp/n1/EZf2YtE\n'
+                                              'BpxJAgqdwej8beWV16QXOnKXQpsGAeu7x2pvOGFyRGytmLDeUXayfIF/E46w83V2\n'
+                                              'r53NOBrlezagqCAz9uafocyNaXlxZfp4tx82sEmpSmHGwd//+n6zgXNC0QIDAQAB\n'
+                                              'AoGAd5EIA1GMPYCLhSNp+82ueARGKcHwYrzviU8ob5D/cVtge5P26YRlbxq2sEyf\n'
+                                              'oWBCTgJGW5mlrNuWZ4mFPq1NP2X2IU80k/J67KOuOelAykIVQw6q6GAjtmh40x4N\n'
+                                              'EekoFzxVqoFKqWOJ1UNP0jNOyfzxU5dfzvw5GOEXob9usjECQQD3++wWCoq+YRCz\n'
+                                              '8qqav2M7leoAnDwmCYKpnugDU0NR61sZADS3kJHnhXAbPFQI4dRfETJOkKE/iDph\n'
+                                              'G0Rtdfm1AkEA06VoI49wjEMYs4ah3qwpvhuVyxVa9iozIEoDYiVCOOBZw8rX79G4\n'
+                                              '+5yzC9ehy9ugWttSA2jigNXVB6ORN3+mLQJBAM47lZizBbXUdZahvp5ZgoZgY65E\n'
+                                              'QIWFrUOxYtS5Hyh2qlk9YZozwhOgVp5f6qdEYGD7pTHPeDqk6aAulBbQYW0CQQC4\n'
+                                              'hAw2dGd64UQ3v7h/mTkLNKFzXDrhQgkwrVYlyrXhQDcCK2X2/rB3LDYsrOGyCNfU\n'
+                                              'XkEyF87g44vGDSQdbnxBAkA1Y+lB/pqdyHMv5RFabkBvU0yQDfekAKHeQ6rS+21g\n'
+                                              'dWedUVc1JNnKtb8W/rMfdjg9YLYqUTvoBvp0DjfwdYc4\n'
+                                              '-----END RSA PRIVATE KEY-----',
+            'storage.cloud_front_key_id': 'key-id'
+        }
+        conn = boto.connect_s3()
+        self.bucket = conn.create_bucket('mybucket')
+        patch.object(CloudFrontS3Storage, 'test', True).start()
+        kwargs = CloudFrontS3Storage.configure(self.settings)
+        self.storage = CloudFrontS3Storage(MagicMock(), **kwargs)
+
+    def test_get_url(self):
+        """ Mock s3 and test package url generation """
+        package = make_package()
+        response = self.storage.download_response(package)
+
+        parts = urlparse(response.location)
+        self.assertEqual(parts.scheme, 'https')
+        self.assertEqual(parts.netloc, 'abcdef.cloudfront.net')
+        self.assertEqual(parts.path, '/' + self.storage.get_path(package))
+        query = parse_qs(parts.query)
+        self.assertItemsEqual(query.keys(), ['Key-Pair-Id', 'Expires',
+                                             'Signature'])
+        self.assertTrue(int(query['Expires'][0]) > time.time())
+        self.assertEqual(query['Key-Pair-Id'][0],
+                         self.settings['storage.cloud_front_key_id'])
 
 
 class TestFileStorage(unittest.TestCase):


### PR DESCRIPTION
To deliver package binaries faster I've built upon the S3 storage backend to support generating URLs to CloudFront instead of S3.

I've verified that this patch works and I'm curious about feedback to make it ready to merge into the official pypycloud distribution.