### PR TITLE
Fix missing newline in config template

### DIFF
--- a/pypicloud/templates/config.ini.jinja2
+++ b/pypicloud/templates/config.ini.jinja2
@@ -57,7 +57,7 @@ enable-threads = true
 {%- if env == 'docker' %}
 http = 0.0.0.0:8080
 virtualenv = /env
-{%- else -%}
+{%- else %}
 socket = 127.0.0.1:3031
 {% if venv is defined -%}virtualenv = {{ venv }}{%- endif %}
 {%- endif %}


### PR DESCRIPTION
Fix missing newline in config template

Before:
```ini
[uwsgi]
...
enable-threads = truesocket = 127.0.0.1:3031
```

After:
```ini
[uwsgi]
...
enable-threads = true
socket = 127.0.0.1:3031
```