### PR TITLE
Sort package in /simple view

### DIFF
--- a/pypicloud/templates/package.jinja2
+++ b/pypicloud/templates/package.jinja2
@@ -4,7 +4,7 @@
   <title>Package Index</title>
 </head>
 <body>
-  {% for filename, url in pkgs.iteritems() %}
+  {% for filename, url in pkgs|dictsort %}
     <a href="{{ url }}">{{ filename }}</a><br>
   {%- endfor %}
 </body>


### PR DESCRIPTION
Makes the package versions easier to visually parse by sorting alphabetically :smile:  Sorting by version would be nicer but this seems like a quick win.

Testing with http://mybox:6543/simple/bravado_core/

Before:
```
bravado_core-4.2.2-py2-none-any.whl
bravado_core-4.2.0-py2-none-any.whl
bravado_core-0.1.0-py2-none-any.whl
bravado_core-4.2.1-py2-none-any.whl
```

After:
```
bravado_core-0.1.0-py2-none-any.whl
bravado_core-4.2.0-py2-none-any.whl
bravado_core-4.2.1-py2-none-any.whl
bravado_core-4.2.2-py2-none-any.whl
```

