### PR TITLE
adds __pypicloud_ldap_admin__ as an admin service account

### DIFF
--- a/doc/topics/access_control.rst
+++ b/doc/topics/access_control.rst
@@ -356,3 +356,9 @@ will depend on your LDAP setup.
 
 A list of DNs to search for who should be considered an admin. It uses the
 ``admin_field`` to determine the source of admin DNs in the returned record(s).
+
+``auth.ldap.service_account``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+**Argument:** string, optional
+
+A username for the service DN to self-authenticate as admin.

--- a/pypicloud/access/ldap_.py
+++ b/pypicloud/access/ldap_.py
@@ -75,7 +75,7 @@ class LDAP(object):
             ldap.SCOPE_SUBTREE,
             LDAP._all_user_search,
         )
-        LDAP._all_users = {}
+        LDAP._all_users = {"__pypicloud_ldap_admin__": LDAP._service_dn}
         for result in results:
             if LDAP._id_field in result[1]:
                 LDAP._all_users[result[1][LDAP._id_field][0]] = result[0]
@@ -142,8 +142,8 @@ class LDAP(object):
         Returns a list of all the admin DNs
         """
         if not hasattr(LDAP, "_admins"):
-            LDAP._admins = []
-            LDAP._admin_usernames = []
+            LDAP._admins = [LDAP._service_dn]
+            LDAP._admin_usernames = ["__pypicloud_ldap_admin__"]
             for admin_dn in LDAP._admin_dns:
                 LDAP._add_admins_from_dn(admin_dn)
 

--- a/pypicloud/access/ldap_.py
+++ b/pypicloud/access/ldap_.py
@@ -53,6 +53,7 @@ class LDAP(object):
         LDAP._admin_dns = [
             dn for dn in settings["auth.ldap.admin_dns"].splitlines() if dn
         ]
+        LDAP._service_account = settings.get("auth.ldap.service_account")
 
         LDAP._connect()
 
@@ -75,7 +76,9 @@ class LDAP(object):
             ldap.SCOPE_SUBTREE,
             LDAP._all_user_search,
         )
-        LDAP._all_users = {"__pypicloud_ldap_admin__": LDAP._service_dn}
+        LDAP._all_users = {}
+        if LDAP._service_account:
+            LDAP._all_users[LDAP._service_account] = LDAP._service_dn
         for result in results:
             if LDAP._id_field in result[1]:
                 LDAP._all_users[result[1][LDAP._id_field][0]] = result[0]
@@ -143,7 +146,9 @@ class LDAP(object):
         """
         if not hasattr(LDAP, "_admins"):
             LDAP._admins = [LDAP._service_dn]
-            LDAP._admin_usernames = ["__pypicloud_ldap_admin__"]
+            LDAP._admin_usernames = []
+            if LDAP._service_account:
+                LDAP._admin_usernames.append(LDAP._service_account)
             for admin_dn in LDAP._admin_dns:
                 LDAP._add_admins_from_dn(admin_dn)
 


### PR DESCRIPTION
since the service account is configured via full DN, this adds the user name `__pypicloud_ldap_admin__` which is tied to the service account DN. if you know the password to pypicloud's ldap service account you can probably get admin access via other methods anyway... handy to have a service account though.

if you think it should be a different name I'm not very particular to `__pypicloud_ldap_admin__`, just wanted it to be something unlikely to be a regular account name