### PR TITLE
Don't allow anonymous ldap binding

### DIFF
--- a/pypicloud/access/ldap_.py
+++ b/pypicloud/access/ldap_.py
@@ -169,6 +169,9 @@ class LDAP(object):
         """
         Attempts to bind as the user, then rebinds as service user again
         """
+        if password == "":
+            return False
+        
         try:
             LDAP._server.simple_bind_s(user_dn, password)
         except ldap.INVALID_CREDENTIALS:


### PR DESCRIPTION
At least against ActiveDirectory I am able to use basic auth
with an empty password and a valid username and python-ldap
does an anonymous bind to the server and does not throw an
ldap.INVALID_CREDENTIALS error. This allows anyone that
knows a valid username to use the server with basic auth. This
simple guard prevents this from happening.