### PR TITLE
retrieve metadata for each key individually

### DIFF
--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -130,9 +130,9 @@ class S3Storage(IStorage):
     def list(self, factory=Package):
         keys = self.bucket.list(self.bucket_prefix)
         for key in keys:
-            # Moto doesn't send down metadata from bucket.list()
-            if self.test:
-                key = self.bucket.get_key(key.key)
+            # Boto doesn't send down metadata from bucket.list()
+            # so we are forced to retrieve each key individually.
+            key = self.bucket.get_key(key.key)
             filename = posixpath.basename(key.key)
             name = key.get_metadata('name')
             version = key.get_metadata('version')


### PR DESCRIPTION
From the [boto docs](http://boto.cloudhackers.com/en/latest/ref/s3.html#module-boto.s3.bucket) for the `bucket.list` method:

> The Key objects returned by the iterator are obtained by parsing the results of a GET on the bucket, also known as the List Objects request. The XML returned by this request contains only a subset of the information about each key. Certain metadata fields such as Content-Type and user metadata are not available in the XML. Therefore, if you want these additional metadata fields you will have to do a HEAD request on the Key in the bucket.

So it looks like it's not just Moto, but any call to `bucket.list`. I noticed this behavior after rebuilding the cache, and finding that some package names/versions (interpreted by the fallback `parse_filename`) were different than those recorded in the metadata.